### PR TITLE
Asynchronous selectedItems

### DIFF
--- a/src/react-native-selectize.js
+++ b/src/react-native-selectize.js
@@ -92,8 +92,9 @@ export default class ReactNativeSelectize extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     const items = this._getNormalizedItems(nextProps);
+    const selectedItems = this._getNormalizedSelectedItems(nextProps);
 
-    this.setState({ items });
+    this.setState({ items, selectedItems });
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
The selectedItems are set in the component constructor. If they are set after the component initialization, they will not be displayed.

A solution is looking for selectedItems changes in the componentWillReceiveProps hook.