### PR TITLE
Fix TextInput text not clearing after submit on Android.

### DIFF
--- a/src/react-native-selectize.js
+++ b/src/react-native-selectize.js
@@ -206,6 +206,12 @@ export default class ReactNativeSelectize extends React.Component {
       this._setSelectedItems(selectedItems);
     }
     this.setState({ text: '' });
+
+    // Hack for Android devices to reset keyboard state. Otherwise TextInput does not properly clear 
+    // previously inputted text.
+    // See: https://stackoverflow.com/questions/37798584/react-native-when-submitting-a-text-input-in-android-the-word-suggestions-are
+    this._textInput.setNativeProps({keyboardType:"email-address"});
+    this._textInput.setNativeProps({keyboardType:"default"});
   };
 
   _onFocus = callback => {


### PR DESCRIPTION
Hello @raynor85 ,

Thanks for this great library! I encountered a bug on Android devices (specifically a Galaxy S8 running Android 8.0.0) in which the text input does not clear after hitting submit. The input appears to clear, but once typing is resumed the old text appears again.

Here you can see the bug. Note that I am only typing one 'h' when the input is focused the second time but 'hh' appears:
![selectize_bug](https://user-images.githubusercontent.com/527947/49332870-cc22bd00-f569-11e8-82a1-35719584796c.gif)

And the fix. Only one 'h' appears the second time the input is focused. 
![selectize_fix](https://user-images.githubusercontent.com/527947/49332871-cc22bd00-f569-11e8-9837-abda4a3a1761.gif)

Relevant stack overflow discussions:
https://stackoverflow.com/questions/37798584/react-native-when-submitting-a-text-input-in-android-the-word-suggestions-are
https://stackoverflow.com/questions/43233223/react-native-text-input-clear-doesnt-clear-text
